### PR TITLE
feat: Reader app module

### DIFF
--- a/reader_application/README.md
+++ b/reader_application/README.md
@@ -31,7 +31,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="application_name"></a> [application\_name](#) | (Required) App registration unique name. | `string` | n/a | yes |
 | <a name="secret_description"></a> [secret\_description](#) | (Required) Description of the app's secret. | `string` | n/a | yes |
-| <a name="accessible_subscriptions"></a> [accessible\_subscriptions](#) | (Required) The subscriptions ids that the application can read. | `list(string)` | n/a | yes |
+| <a name="subscription_id"></a> [subscription\_id](#) | (Required) Subscription of the `default-roleassignment-rg` resouce group. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/reader_application/README.md
+++ b/reader_application/README.md
@@ -1,0 +1,41 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="azuread"></a> [azuread](#azuread) | ~>2.15.0 |
+| <a name="azurerm"></a> [azurerm](#azurerm) | =2.91.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="azuread"></a> [azuread](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0) | ~>2.15.0 |
+| <a name="azurerm"></a> [azurerm](https://registry.terraform.io/providers/hashicorp/azurerm/2.96.0) | =2.96.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azuread\_application.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
+| [azuread\_application\_password.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
+| [azuread\_service\_principal.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
+| [azurerm\_role\_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="application_name"></a> [application\_name](#) | (Required) App registration unique name. | `string` | n/a | yes |
+| <a name="secret_description"></a> [secret\_description](#) | (Required) Description of the app's secret. | `string` | n/a | yes |
+| <a name="accessible_subscriptions"></a> [accessible\_subscriptions](#) | (Required) The subscriptions ids that the application can read. | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="client_id"></a> [client\_id](#) | (Required) The client id of the app registration. |
+| <a name="client_secret"></a> [client\_secret](#) | (Required) The client secret of the app registration. |

--- a/reader_application/README.md
+++ b/reader_application/README.md
@@ -2,15 +2,15 @@
 
 | Name | Version |
 |------|---------|
-| <a name="azuread"></a> [azuread](#azuread) | ~>2.15.0 |
-| <a name="azurerm"></a> [azurerm](#azurerm) | =2.91.0 |
+| <a name="azuread"></a> [azuread](#azuread) | =2.10.0 |
+| <a name="azurerm"></a> [azurerm](#azurerm) | =2.90.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="azuread"></a> [azuread](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0) | ~>2.15.0 |
-| <a name="azurerm"></a> [azurerm](https://registry.terraform.io/providers/hashicorp/azurerm/2.96.0) | =2.96.0 |
+| <a name="azuread"></a> [azuread](https://registry.terraform.io/providers/hashicorp/azuread/2.10.0) | =2.10.0 |
+| <a name="azurerm"></a> [azurerm](https://registry.terraform.io/providers/hashicorp/azurerm/2.90.0) | =2.90.0 |
 
 ## Modules
 

--- a/reader_application/main.tf
+++ b/reader_application/main.tf
@@ -1,12 +1,10 @@
 terraform {
   required_providers {
     azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.15.0"
+      source = "hashicorp/azuread"
     }
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "=2.96.0"
+      source = "hashicorp/azurerm"
     }
   }
 }
@@ -18,7 +16,7 @@ resource "azuread_application" "this" {
 
 resource "azuread_application_password" "this" {
   application_object_id = azuread_application.this.object_id
-  description           = var.secret_description
+  display_name          = var.secret_description
 }
 
 resource "azuread_service_principal" "this" {

--- a/reader_application/main.tf
+++ b/reader_application/main.tf
@@ -26,9 +26,7 @@ resource "azuread_service_principal" "this" {
 }
 
 resource "azurerm_role_assignment" "this" {
-  for_each = toset(var.accessible_subscriptions)
-
-  principal_id       = azuread_service_principal.this.id
-  role_definition_id = "Reader"
-  scope              = "/subscriptions/${each.value}"
+  principal_id         = azuread_service_principal.this.id
+  role_definition_name = "Reader"
+  scope                = "/subscriptions/${var.subscription_id}/resourceGroups/default-roleassignment-rg"
 }

--- a/reader_application/main.tf
+++ b/reader_application/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.15.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=2.96.0"
+    }
+  }
+}
+
+resource "azuread_application" "this" {
+  display_name            = var.application_name
+  prevent_duplicate_names = true
+}
+
+resource "azuread_application_password" "this" {
+  application_object_id = azuread_application.this.object_id
+  description           = var.secret_description
+}
+
+resource "azuread_service_principal" "this" {
+  application_id = azuread_application.this.application_id
+}
+
+resource "azurerm_role_assignment" "this" {
+  for_each = toset(var.accessible_subscriptions)
+
+  principal_id       = azuread_service_principal.this.id
+  role_definition_id = "Reader"
+  scope              = "/subscriptions/${each.value}"
+}

--- a/reader_application/outputs.tf
+++ b/reader_application/outputs.tf
@@ -1,0 +1,10 @@
+output "client_id" {
+  value       = azuread_application.this.application_id
+  description = "The client id of the registration."
+}
+
+output "client_secret" {
+  value       = azuread_application_password.this.value
+  description = "The client secret of the registration."
+  sensitive   = true
+}

--- a/reader_application/variables.tf
+++ b/reader_application/variables.tf
@@ -1,0 +1,14 @@
+variable "application_name" {
+  type        = string
+  description = "(Required) App registration unique name."
+}
+
+variable "secret_description" {
+  type        = string
+  description = "(Required) Description of the app's secret."
+}
+
+variable "accessible_subscriptions" {
+  type        = list(string)
+  description = "(Required) The subscriptions ids that the application can read."
+}

--- a/reader_application/variables.tf
+++ b/reader_application/variables.tf
@@ -8,7 +8,7 @@ variable "secret_description" {
   description = "(Required) Description of the app's secret."
 }
 
-variable "accessible_subscriptions" {
-  type        = list(string)
-  description = "(Required) The subscriptions ids that the application can read."
+variable "subscription_id" {
+  type        = string
+  description = "(Required) Subscription of the `default-roleassignment-rg` resouce group."
 }


### PR DESCRIPTION
### List of changes

This PR adds a module to register an application inside AzureAD with Reader permission on a particular resource group: `default-roleassignment-rg` in `DevOpsLab` subscription.

### Motivation and context

Lots of the 3rd party applications require a `client_id` and a `client_secret` to access Azure resources. I need those values to connect Grafana with the Azure cloud services.

### Type of changes

- [x] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

It also generates the `client_secret` and gives its value in the output. You cannot retrieve the secret above this moment.
